### PR TITLE
Adding Support for Gnome 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "uuid": "panel-corners@aunetx",
   "settings-schema": "org.gnome.shell.extensions.panel-corners",
   "shell-version": [
+    "42",
     "43"
   ],
   "version": 5

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "uuid": "panel-corners@aunetx",
   "settings-schema": "org.gnome.shell.extensions.panel-corners",
   "shell-version": [
-    "42"
+    "43"
   ],
   "version": 5
 }


### PR DESCRIPTION
just updated the metadata to gnome 43, works just fine on OpenSuse Tumbleweed Gnome 43