### PR TITLE
Version 7 for gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
   "settings-schema": "org.gnome.shell.extensions.panel-corners",
   "shell-version": [
     "42",
-    "43"
+    "43",
+    "44"
   ],
-  "version": 6
+  "version": 7
 }


### PR DESCRIPTION
Working normally on Gnome 44:

![Screenshot from 2023-04-21 18-04-54](https://user-images.githubusercontent.com/17055027/233734477-f8a5844b-a5fd-4458-874a-4f000d5a6bc6.png)
