### PR TITLE
Adjust the panel corner transition

### DIFF
--- a/src/panel_corner.js
+++ b/src/panel_corner.js
@@ -8,7 +8,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 
 const SYNC_CREATE = GObject.BindingFlags.SYNC_CREATE;
-
+const ANIMATION_TIME = imports.ui.overview.ANIMATION_TIME;
 
 var PanelCorners = class PanelCorners {
     constructor(prefs, connections) {
@@ -204,9 +204,6 @@ const PanelCorner = GObject.registerClass(
             let cornerRadius = Utils.lookup_for_length(node, '-panel-corner-radius', this._prefs);
             let borderWidth = Utils.lookup_for_length(node, '-panel-corner-border-width', this._prefs);
 
-            const transitionDuration =
-                node.get_transition_duration() / St.Settings.get().slow_down_factor;
-
             let opacity = Utils.lookup_for_double(node, '-panel-corner-opacity', this._prefs);
 
             // if using extension values and in overview, set transparent
@@ -224,7 +221,7 @@ const PanelCorner = GObject.registerClass(
             this.remove_transition('opacity');
             this.ease({
                 opacity: opacity * 255,
-                duration: transitionDuration,
+                duration: ANIMATION_TIME,
                 mode: Clutter.AnimationMode.EASE_IN_OUT_QUAD,
             });
         }


### PR DESCRIPTION
Fixes #21

Replaces the panel corner duration transition with the overview animation time (ANIMATION_TIME).

Before:
![old](https://user-images.githubusercontent.com/85074776/233839338-716b529c-16a6-4f17-be68-12135388bad5.gif)

After:
![fixed](https://user-images.githubusercontent.com/85074776/233839348-daf5e5b7-9803-495d-9b8e-a6f09bd88ee1.gif)


